### PR TITLE
:art: Unroll refund logic

### DIFF
--- a/model/mechanisms.py
+++ b/model/mechanisms.py
@@ -110,7 +110,82 @@ def deposit_and_update_total(
     return ("totalDeposited", current_state["totalDeposited"] + deposit_amount)
 
 
-def refund(
+def refund_funder_account(
+    sys_params: dict[str, Any],
+    substep: int,
+    _,
+    current_state: dict[str, Any],
+    policy_inputs: dict[str, Any],
+):
+    default = ("deposited", current_state["deposited"])
+    if policy_inputs["step"] != "depositing":
+        return default
+
+    dice_roll = uniform(0.1, 0.9)
+
+    agents: list[dict[str, Any]] = current_state["agents"]
+    i_funder = -1
+    for i_agent in range(0, len(agents) - 1):
+        substep_criteria_met = (
+            agents[i_agent]["DAI"] == 0
+            and current_state["deposited"][agents[i_agent]["address"]] > 0
+        )
+        if substep_criteria_met:
+            i_funder = i_agent
+            break
+
+    if i_funder < 0:
+        return default
+
+    refunder = agents[i_funder]
+    agent_opts_to_not_deposit = refunder["probabilities"]["refund"] < dice_roll
+    if agent_opts_to_not_deposit:
+        return default
+
+    funder_address = refunder["address"]
+    to_be_refunded = current_state["deposited"][funder_address]
+
+    return (
+        "deposited",
+        current_state["deposited"].update(
+            {
+                funder_address: current_state["deposited"][funder_address]
+                - to_be_refunded
+            }
+        ),
+    )
+
+
+def refund_and_credit_DAI(
+    sys_params: dict[str, Any],
+    substep: int,
+    _,
+    current_state: dict[str, Any],
+    policy_inputs: dict[str, Any],
+):
+    default = ("agents", current_state["agents"])
+    if policy_inputs["step"] != "depositing":
+        return default
+
+    agents: list[dict[str, Any]] = current_state["agents"]
+    i_funder = -1
+    for i_agent in range(0, len(agents) - 1):
+        substep_criteria_met = (
+            agents[i_agent]["DAI"] == 0
+            and current_state["deposited"][agents[i_agent]["address"]] == 0
+        )
+        if substep_criteria_met:
+            i_funder = i_agent
+            break
+
+    if i_funder < 0:
+        return default
+
+    agents[i_funder]["DAI"] = initial_state["agents"][i_funder]["DAI"]
+    return ("agents", agents)
+
+
+def refund_and_update_total(
     sys_params: dict[str, Any],
     substep: int,
     _,
@@ -121,30 +196,23 @@ def refund(
     if policy_inputs["step"] != "depositing":
         return default
 
-    dice_roll = uniform(0.1, 0.9)
-
-    agents: list[dict[str, Any]] = sys_params["agents"]
-    i_refunder = -1
+    agents: list[dict[str, Any]] = current_state["agents"]
+    i_funder = -1
     for i_agent in range(0, len(agents) - 1):
-        if agents[i_agent]["DAI"] == 0:
-            i_refunder = i_agent
+        substep_criteria_met = (
+            current_state["agents"][i_agent]["DAI"] > 0
+            and current_state["deposited"][agents[i_agent]["address"]] == 0
+        )
+        if substep_criteria_met:
+            i_funder = i_agent
             break
 
-    if i_refunder < 0:
+    if i_funder < 0:
         return default
 
-    refunder = agents[i_refunder]
-    agent_opts_to_not_refund = refunder["probabilities"]["refund"] < dice_roll
-    if agent_opts_to_not_refund:
-        return default
+    to_be_refunded = initial_state["agents"][i_funder]["DAI"]
 
-    refunder_address = refunder["address"]
-    to_be_refunded = current_state["deposited"][refunder_address]
-    if to_be_refunded == 0:
-        return default
-
-    current_state["deposited"][refunder_address] = 0
-    sys_params["agents"][i_refunder]["DAI"] += to_be_refunded
+    return ("totalDeposited", current_state["totalDeposited"] - to_be_refunded)
 
 
 def exchange(

--- a/model/partial_state_update_block.py
+++ b/model/partial_state_update_block.py
@@ -6,7 +6,9 @@ from .mechanisms import (
     deposit_into_funder_account,
     exchange,
     liquidate,
-    refund,
+    refund_and_credit_DAI,
+    refund_and_update_total,
+    refund_funder_account,
     vote_liquidate,
 )
 
@@ -22,12 +24,11 @@ from .policies import (
 
 block_step_1 = [
     {
-        "policies": {"deposit_policy": deposit_policy, "refund_policy": refund_policy},
+        "policies": {"deposit_policy": deposit_policy},
         "variables": {
             "deposit_into_funder": deposit_into_funder_account,
             "deposit_deplete_dai": deposit_and_deplete_DAI,
             "deposit_update_total": deposit_and_update_total,
-            "refund": refund,
         },
     }
     for _ in range(0, 9)
@@ -35,12 +36,24 @@ block_step_1 = [
 
 block_step_2 = [
     {
+        "policies": {"deposit_policy": refund_policy},
+        "variables": {
+            "deposit_into_funder": refund_funder_account,
+            "deposit_deplete_dai": refund_and_credit_DAI,
+            "deposit_update_total": refund_and_update_total,
+        },
+    }
+    for _ in range(0, 9)
+]
+
+block_step_3 = [
+    {
         "policies": {"exchange_policy": exchange_policy},
         "variables": {"exchange": exchange},
     }
 ]
 
-block_step_3 = [
+block_step_4 = [
     {
         "policies": {"claimMTokens_policy": claimMTokens_policy},
         "variables": {"claimMTokens": claimMTokens},
@@ -48,7 +61,7 @@ block_step_3 = [
     for _ in range(0, 9)
 ]
 
-block_step_4 = [
+block_step_5 = [
     {
         "policies": {
             "vote_liquidate_policicy": vote_liquidate_policy,
@@ -59,7 +72,7 @@ block_step_4 = [
     for _ in range(0, 9)
 ]
 
-block_step_5 = [
+block_step_6 = [
     {
         "policies": {"claim_policy": claim_policy},
         "variables": {"claim": claim},
@@ -67,7 +80,14 @@ block_step_5 = [
     for _ in range(0, 9)
 ]
 
-block_steps = [block_step_1, block_step_2, block_step_3, block_step_4, block_step_5]
+block_steps = [
+    block_step_1,
+    block_step_2,
+    block_step_3,
+    block_step_4,
+    block_step_5,
+    block_step_6,
+]
 partial_state_update_block = []
 
 for block_step in block_steps:


### PR DESCRIPTION
## Summary
Fixes #1 

## Details
As specified in the [cadCAD docs](https://github.com/cadCAD-org/cadCAD/tree/master/documentation#state-update-functions), state update functions should only update one state variable at a time.

This PR ensures this pattern is followed.