### PR TITLE
:sparkles: Using `substep` for model time

### DIFF
--- a/model/mechanisms/exhange.py
+++ b/model/mechanisms/exhange.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from datetime import datetime
 from typing import Any
 
 
@@ -13,7 +12,7 @@ def exchange_set_exchange_time(
     if policy_inputs["step"] != "exchanging":
         return ("exchangeTime", current_state["exchangeTime"])
 
-    return ("exchangeTime", datetime.utcnow().replace(microsecond=0).timestamp())
+    return ("exchangeTime", substep)
 
 
 def exchange_send_mTokens(

--- a/model/mechanisms/liquidate.py
+++ b/model/mechanisms/liquidate.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from datetime import datetime
 from typing import Any
 
 
@@ -57,4 +56,4 @@ def liquidate_tokens(
     if policy_inputs["substep"] != "unanimous liquidation vote":
         return ("liquidationTime", current_state["liquidationTime"])
 
-    return ("liquidationTime", datetime.utcnow().replace(microsecond=0).timestamp())
+    return ("liquidationTime", substep)

--- a/model/policies/liquidate.py
+++ b/model/policies/liquidate.py
@@ -22,7 +22,11 @@ def vote_liquidate_policy(
         if agent_will_vote:
             agents_to_keep.append(agents[i_agent])
 
-    if len(agents_to_keep) > 0 and current_state["exchangeTime"] > 0:
+    if (
+        len(agents_to_keep) > 0
+        and current_state["exchangeTime"] > 0
+        and substep >= current_state["exchangeTime"] + current_state["lockingDuration"]
+    ):
         return {"step": "post-exchange", "agents": agents_to_keep}
     else:
         return default
@@ -36,8 +40,8 @@ def liquidate_policy(
 ):
     criteria_for_liquidation_met = (
         current_state["totalDeposited"] == current_state["totalVotedForLiquidation"]
+        and substep >= current_state["exchangeTime"] + current_state["lockingDuration"]
     )
     if criteria_for_liquidation_met:
         return {"substep": "unanimous liquidation vote"}
     return {"substep": "continue"}
-


### PR DESCRIPTION
## Summary
Closes #13

Uses substep vs. timestep as it makes more sense in the context of cadCAD.